### PR TITLE
Added POS and lemma annotation renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ Allowed values are any single category name or pipe separated sequences of categ
 The default value for this attribute is morph (for 'morphological annotation').
 If no / attribute is defined for both the POSTAG and the CPOSTAG value of a data row, the default name [VALUE] is used for the Annotation (or Annotations, see ) of the corresponding salt token. The data row´s FEATS field is used as the value of the annotation(s). 
 
+### conll.POS.NAME
+Usage: conll.POS.NAME=[VALUE]
+A string specifying a valid annotation name for the POS annotation. Allowed values are any valid Salt annotation name. If not used and POS or CPOS are being used, then a default Salt SPOSAnnotation will be created and named 'pos'
+
+### conll.POS.LEMMA
+Usage: conll.POS.LEMMA=[VALUE]
+A string specifying a valid annotation name for the lemma annotation. Allowed values are any valid Salt annotation name. If not used and conll.SLEMMA is being used, then a default Salt SLemmaAnnotation will be created and named 'lemma', provided that column 3 contains non-empty lemma values.
+
 ### conll.splitFeatures
 Usage: conll.splitFeatures=[VALUE]
  If [VALUE] is set TRUE, any data row´s FEATS field will be split into it´s pipe separated elements to create multiple annotations on the corresponding salt token (see POSTAG, CPOSTAG and default). If a field contains a different number of pipe separated elements than defined in the POSTAG, CPOSTAG or default attribute, the lesser number of annotations will be created, while the additional elements will be lost! 

--- a/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
@@ -51,6 +51,8 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 																					// at
 																					// the
 																					// end
+	public final static String PROP_POS_NAME = PREFIX + "POS.NAME";
+	public final static String PROP_LEMMA_NAME = PREFIX + "LEMMA.NAME";
 																					// is
 																					// correct
 	public final static String PROP_FIELD6_DEFAULT = PREFIX + "field6.default";
@@ -72,6 +74,8 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 		this.addProperty(new PepperModuleProperty<String>(PROP_FIELD6_POSTAG, String.class, "This is not only a single property, but a class of properties. Multiple entries of this type may be given in a properties file, but [TAG] must be unique. A property of this type applies for any input data row that contains the given [TAG] as value for the POSTAG field. The corresponding salt token will get a SAnnotation with [VALUE] as name and the input data row´s FEATS field as value.", false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_FIELD6_CPOSTAG, String.class, "This attribute works like , but instead of POSTAG, the CPOSTAG value of data rows is utilized. ", false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_FIELD6_DEFAULT, String.class, "Allowed values are any single category name or pipe separated sequences of category names", false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_POS_NAME, String.class, "A string specifying a valid annotation name for the POS annotation", false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_LEMMA_NAME, String.class, "A string specifying a valid annotation name for the lemma annotation", false));
 		this.addProperty(new PepperModuleProperty<Boolean>(PROP_SPLIT_FEATURES, Boolean.class, "If [VALUE] is set TRUE, any data row´s FEATS field will be split into it´s pipe separated elements to create multiple annotations on the corresponding salt token (see POSTAG, CPOSTAG and default). If a field contains a different number of pipe separated elements than defined in the POSTAG, CPOSTAG or default attribute, the lesser number of annotations will be created, while the additional elements will be lost! If VALUE is FALSE, no splitting is done.", false, false));
 		this.addProperty(new PepperModuleProperty<Boolean>(PROP_SENTENCE, Boolean.class, "If [VALUE] is set TRUE add a sentence annotation (cat=S) to the data.", true, false));
 
@@ -103,6 +107,13 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 
 	public String getFiel6dDefault() {
 		return ((String) this.getProperty(PROP_FIELD6_DEFAULT).getValue());
+	}
+
+        public String getPosName() {
+		return ((String) this.getProperty(PROP_POS_NAME).getValue());
+	}
+	public String getLemmaName() {
+		return ((String) this.getProperty(PROP_LEMMA_NAME).getValue());
 	}
 
 	public Boolean isSplitFeatures() {

--- a/src/main/java/org/corpus_tools/peppermodules/conll/Conll2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/conll/Conll2SaltMapper.java
@@ -90,7 +90,22 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 	private boolean getSplitFeatures() {
 	  return (Boolean) getProperties().getProperty(CoNLLImporterProperties.PROP_SPLIT_FEATURES).getValue();
 	}
+   
+        // check for user-defined POS and lemma annotation names
+        String posName;
+        String lemmaName;
+        
+        private String getPosName(){
+            //return (String) getProperties().getProperty(CoNLLImporterProperties.PROP_SLEMMA).getValue();
+            return (String) getProperties().getProperties().getProperty(CoNLLImporterProperties.PROP_POS_NAME, "");
+        }
+        
+        private String getLemmaName(){
+            //return (String) getProperties().getProperty(CoNLLImporterProperties.PROP_SLEMMA).getValue();
+            return (String) getProperties().getProperties().getProperty(CoNLLImporterProperties.PROP_LEMMA_NAME, "");
+        }
 
+        
 	boolean useSLemmaAnnotation;
 
 	// retrieves whether or not to use SLemmaAnnoations
@@ -211,8 +226,17 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 						if (field != null) {
 							String fieldVal = fieldValues.get(field.getFieldNum() - 1);
 							if (fieldVal != null) {
-								SPOSAnnotation anno = SaltFactory.createSPOSAnnotation();
-								anno.setValue(fieldVal);
+                                                                SAnnotation anno;
+                                                                if (posName != null && posName.length() > 0){
+                                                                    // This is a custom names POS annotation, use a regular nameable SAnnotation
+                                                                    anno = SaltFactory.createSAnnotation();
+                                                                    anno.setName(posName);                                                             
+                                                                }
+                                                                else{
+                                                                    // Standard Salt Semantics POS tag - make anno into a new SPOSAnnotation 
+                                                                    anno = SaltFactory.createSPOSAnnotation();
+                                                                }
+								anno.setValue(fieldVal);                                                                
 								sToken.addAnnotation(anno);
 								SPOSAnnotationIndex = index;
 							}
@@ -288,7 +312,8 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 		this.useSLemmaAnnotation = getUseSLemmaAnnotation();
 		this.useSPOSAnnotation = getUseSPOSAnnotation();
 		this.splitFeatures = getSplitFeatures();
-		
+                this.posName = getPosName();
+                this.lemmaName = getLemmaName();
 
                 boolean considerProjectivity = (Boolean) getProperties().getProperty(CoNLLImporterProperties.PROP_CONSIDER_PROJECTIVITY).getValue();
                 boolean projectiveModeIsType = !getProperties().getProperties().getProperty(CoNLLImporterProperties.PROP_PROJECTIVE_MODE, TYPE).equalsIgnoreCase(NAMESPACE);
@@ -372,27 +397,17 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 					ConllDataField field = ConllDataField.LEMMA;
 					String fieldValue = fieldValues.get(field.getFieldNum() - 1);
 					if (fieldValue != null) {
-						SAnnotation sAnnotation = null;
+						SAnnotation sAnnotation = SaltFactory.createSAnnotation();
 						if (useSLemmaAnnotation) {
-							sAnnotation = SaltFactory.createSLemmaAnnotation();
-						} else {
-							sAnnotation = SaltFactory.createSAnnotation();
-							sAnnotation.setName(getProperties().getProperties().getProperty(field.getPropertyKey_Name(), field.name())); // use
-																													// user
-																													// specified
-																													// name
-																													// for
-																													// field,
-																													// or
-																													// default:
-																													// the
-																													// field�s
-																													// ConLL
-																													// name
-						}
-
-						sAnnotation.setValue(fieldValue);
-						sToken.addAnnotation(sAnnotation);
+                                                        if (lemmaName != null && lemmaName.length() > 0){
+                                                            sAnnotation.setName(lemmaName);                                                             
+                                                        }
+                                                        else{
+                                                            sAnnotation = SaltFactory.createSLemmaAnnotation();
+                                                        }
+                                                        sAnnotation.setValue(fieldValue);
+                                                        sToken.addAnnotation(sAnnotation);                                                        
+						}                                                 
 					}
 				}
 


### PR DESCRIPTION
  * Added properties conll.POS.NAME and conll.LEMMA.NAME to assign custom pos and lemma annotation names (fixes #4 )
  * Note that custom named annotations are generalized SAnnotations, not SPOSAnnotation and SLemmaAnnotation with the associated Salt semantics.
  * Fixed bug where lemma annotations were being genereated despite switching off conll.SLEMMA (fixes #5 )