### PR TITLE
New options + segmentation

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -24,7 +24,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>CoNLLModules</name>
+	<name>pepperModules-CoNLLModules</name>
 	<comment></comment>
 	<projects>
 	</projects>
@@ -11,20 +11,14 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/README.md
+++ b/README.md
@@ -120,12 +120,15 @@ pepper modules contained in this project
 |---------------------------|-----------------------|-------------|
 |conll.SPOS					|POSTAG, CPOSTAG, NONE	|POSTAG|
 |conll.SLEMMA				|LEMMA, NONE			|LEMMA|
+|conll.EDGE.TYPE		| String	| dep |
 |conll.considerProjectivity	|TRUE, FALSE			|FALSE|
 |conll.projectiveMode		|TYPE, NAMESPACE		|TYPE|
 |conll.field6.POSTAG.TAG	|TRUE, FALSE			|TRUE|
 |conll.field6.CPOSTAG.TAG	|any					| |
 |conll.field6.default		|any					| |
 |conll.splitFeatures		|a single category name or a pipe separated sequence of category names	| morph|
+|conll.KeyValFeatures		| TRUE, FALSE	| FALSE|
+|conll.FEATURES.NAMESPACE		| String	| |
 |conll.SENTENCE		        |TRUE, FALSE	| TRUE|
 
 ### conll.SPOS
@@ -204,6 +207,18 @@ A string specifying a valid annotation name for the lemma annotation. Allowed va
 Usage: conll.splitFeatures=[VALUE]
  If [VALUE] is set TRUE, any data row´s FEATS field will be split into it´s pipe separated elements to create multiple annotations on the corresponding salt token (see POSTAG, CPOSTAG and default). If a field contains a different number of pipe separated elements than defined in the POSTAG, CPOSTAG or default attribute, the lesser number of annotations will be created, while the additional elements will be lost! 
 If VALUE is FALSE, no splitting is done.
+
+### conll.KeyValFeatures
+Usage: conll.KeyValFeatures=[VALUE]
+ If [VALUE] is set TRUE, the features column (col6) is expected to contain pipedelimited pairs of annotation names and values, for example `Case=Gen|Number=Plur`.
+
+ ### conll.FEATURES.NAMESPACE
+Usage: conll.FEATURES.NAMESPACE=[VALUE]
+Sets a separate namespace for annotations in the features column (col6).
+
+ ### conll.EDGE.TYPE
+Usage: conll.EDGE.TYPE=[VALUE]
+Manually sets the edge type for dependency edges (default:dep). This overrides automatic settings from the conll.projectiveMode customization.
 
 ### conll.SENTENCE
 Usage: conll.SENTENCE=[VALUE]

--- a/pom.xml
+++ b/pom.xml
@@ -35,4 +35,17 @@
 		<url>https://github.com/korpling/pepperModules-CoNLLModules.git</url>
 	  <tag>HEAD</tag>
   </scm>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<version>3.1.0</version>
 	</parent>
 	<artifactId>pepperModules-CoNLLModules</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<description>This project provides a Pepper importer for CoNLL data.</description>
 	<url>https://github.com/korpling/pepperModules-CoNLLModules</url>
@@ -30,6 +30,6 @@
 		<connection>scm:git:git://github.com/github.com:korpling/pepperModules-CoNLLModules.git</connection>
 		<developerConnection>scm:git:git@github.com:korpling/pepperModules-CoNLLModules.git</developerConnection>
 		<url>https://github.com/korpling/pepperModules-CoNLLModules.git</url>
-	  <tag>pepperModules-CoNLLModules-1.2.2</tag>
+	  <tag>HEAD</tag>
   </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,11 @@
 		<artifactId>pepper-parentModule</artifactId>
 		<version>3.1.0</version>
 	</parent>
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
 	<artifactId>pepperModules-CoNLLModules</artifactId>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<description>This project provides a Pepper importer for CoNLL data.</description>
 	<url>https://github.com/korpling/pepperModules-CoNLLModules</url>

--- a/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLExporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLExporterProperties.java
@@ -63,13 +63,13 @@ public class CoNLLExporterProperties extends PepperModuleProperties{
 	private static final String[] DEFAULTS = {"salt::lemma", "_", "salt::pos", "_", "func", "_", "_"};
 	/** this marker is supposed to be used when the user does not want to reconfigure a value and stick to the default.*/
 	public static final String MARKER_USE_DEFAULT = "*";
-	/** if provided, a specific segmentation is selected rather than all tokens found in a document */
+	/** if provided, a specific segmentation is selected rather than all tokens found in a document. The segmentation needs to be marked with SOrderRelations with the specified name. */
 	public static final String PROP_SEGMENTATION_NAME = "segmentation.name";
 	
 	public CoNLLExporterProperties(){
 		this.addProperty(new PepperModuleProperty<String>(PROP_COL_CONFIG, String.class, "In this string the annotation names (and collapse instructions) for the CoNLL columns are encoded.", Joiner.on(",").join(DEFAULTS), false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_SPAN_ANNOS, String.class, "This property contains all the annotations that will be found on spans over the tokens, but not the token itself.", "", false));
-		//this.addProperty(PepperModuleProperty.with);
+		this.addProperty(new PepperModuleProperty<String>(PROP_SEGMENTATION_NAME, String.class, "If provided, a specific segmentation is selected rather than all tokens found in a document. The segmentation needs to be marked with SOrderRelations with the specified name.", null, false));
 	}
 	
 	public Map<ConllDataField, String> getColumns(){
@@ -102,5 +102,13 @@ public class CoNLLExporterProperties extends PepperModuleProperties{
 			spanAnnos.add(a.trim());
 		}
 		return spanAnnos;
+	}
+	
+	public String getSegmentationName() {
+		Object value = getProperty(PROP_SEGMENTATION_NAME).getValue();
+		if (value != null) {
+			return (String) value;
+		}
+		return null;
 	}
 }

--- a/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLExporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLExporterProperties.java
@@ -63,10 +63,13 @@ public class CoNLLExporterProperties extends PepperModuleProperties{
 	private static final String[] DEFAULTS = {"salt::lemma", "_", "salt::pos", "_", "func", "_", "_"};
 	/** this marker is supposed to be used when the user does not want to reconfigure a value and stick to the default.*/
 	public static final String MARKER_USE_DEFAULT = "*";
+	/** if provided, a specific segmentation is selected rather than all tokens found in a document */
+	public static final String PROP_SEGMENTATION_NAME = "segmentation.name";
 	
 	public CoNLLExporterProperties(){
 		this.addProperty(new PepperModuleProperty<String>(PROP_COL_CONFIG, String.class, "In this string the annotation names (and collapse instructions) for the CoNLL columns are encoded.", Joiner.on(",").join(DEFAULTS), false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_SPAN_ANNOS, String.class, "This property contains all the annotations that will be found on spans over the tokens, but not the token itself.", "", false));
+		//this.addProperty(PepperModuleProperty.with);
 	}
 	
 	public Map<ConllDataField, String> getColumns(){

--- a/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
@@ -53,6 +53,9 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 																					// end
 	public final static String PROP_POS_NAME = PREFIX + "POS.NAME";
 	public final static String PROP_LEMMA_NAME = PREFIX + "LEMMA.NAME";
+	public final static String PROP_EDGETYPE_NAME = PREFIX + "EDGE.TYPE";
+	public final static String PROP_FEATURES_NAMESPACE = PREFIX + "FEATURES.NAMESPACE";
+	public final static String PROP_KEYVAL_FEATURES = PREFIX + "KeyValFeatures";
 																					// is
 																					// correct
 	public final static String PROP_FIELD6_DEFAULT = PREFIX + "field6.default";
@@ -76,7 +79,10 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 		this.addProperty(new PepperModuleProperty<String>(PROP_FIELD6_DEFAULT, String.class, "Allowed values are any single category name or pipe separated sequences of category names", false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_POS_NAME, String.class, "A string specifying a valid annotation name for the POS annotation", false));
 		this.addProperty(new PepperModuleProperty<String>(PROP_LEMMA_NAME, String.class, "A string specifying a valid annotation name for the lemma annotation", false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_EDGETYPE_NAME, String.class, "A string specifying a valid edge type name for the dependency edges (e.g. 'dep')", false));
 		this.addProperty(new PepperModuleProperty<Boolean>(PROP_SPLIT_FEATURES, Boolean.class, "If [VALUE] is set TRUE, any data row´s FEATS field will be split into it´s pipe separated elements to create multiple annotations on the corresponding salt token (see POSTAG, CPOSTAG and default). If a field contains a different number of pipe separated elements than defined in the POSTAG, CPOSTAG or default attribute, the lesser number of annotations will be created, while the additional elements will be lost! If VALUE is FALSE, no splitting is done.", false, false));
+		this.addProperty(new PepperModuleProperty<Boolean>(PROP_KEYVAL_FEATURES, Boolean.class, "If [VALUE] is set TRUE, it is assumed that the FEATS column contains pipe-delimited annotation names and values such as Case=Gen|Number=Plur.", false, false));
+		this.addProperty(new PepperModuleProperty<String>(PROP_FEATURES_NAMESPACE, String.class, "Namespace to assign to features annotations in column 6.", null, false));
 		this.addProperty(new PepperModuleProperty<Boolean>(PROP_SENTENCE, Boolean.class, "If [VALUE] is set TRUE add a sentence annotation (cat=S) to the data.", true, false));
 
 	}
@@ -115,11 +121,21 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 	public String getLemmaName() {
 		return ((String) this.getProperty(PROP_LEMMA_NAME).getValue());
 	}
+	public String getEdgeTypeName() {
+		return ((String) this.getProperty(PROP_EDGETYPE_NAME).getValue());
+	}
+	public String getFeaturesNamespace() {
+		return ((String) this.getProperty(PROP_FEATURES_NAMESPACE).getValue());
+	}
 
 	public Boolean isSplitFeatures() {
 		return ((Boolean) this.getProperty(PROP_SPLIT_FEATURES).getValue());
 	}
-	
+
+	public Boolean isKeyValFeatures() { 
+		return ((Boolean) this.getProperty(PROP_KEYVAL_FEATURES).getValue());
+	}
+
 	public Boolean isSentence() {
     return ((Boolean) this.getProperty(PROP_SENTENCE).getValue());
   }


### PR DESCRIPTION
  * New export from segmentation option by @MartinKl 
  * New settings added by @amir-zeldes : 
    * EDGE.TYPE - manually set an arbitrary edge type
    * FEATURES.NAMESPACE - set a name space for features column annotations
    * KeyValFeatures - allows import of pipedelimited named key value pairs as in the conll-u format (e.g. `Case=Gen|Number=Plur`)