### PR TITLE
implemented #20

### DIFF
--- a/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
+++ b/src/main/java/org/corpus_tools/peppermodules/CoNLLModules/CoNLLImporterProperties.java
@@ -104,6 +104,9 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 
         /** Annotation key names (hyphen-separated) for CoNLL-Coref-style markables in MISC field if present.  GRP denotes edge cluster, EDGE denotes edge type. Default: entity-GRP-identity */
 	public static final String MARK_LABELS = PREFIX + "markable.labels";
+	
+	/** If this is set to true, the importer imports token ID and head ID as token annotations. **/
+	public static final String PROP_IMPORT_IDS = PREFIX + "import.ids";
         
 	public CoNLLImporterProperties() {
 		this.addProperty(new PepperModuleProperty<String>(PROP_SPOS, String.class,
@@ -210,6 +213,12 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 				.withDescription("Annotation key names (hyphen-separated) for CoNLL-Coref-style markables in MISC field if present. GRP denotes edge cluster, EDGE denotes edge type. Default: entity-GRP-identity")
                                 .withDefaultValue("entity-GRP-identity")
 				.build());	
+		addProperty(PepperModuleProperty.create()
+				.withName(PROP_IMPORT_IDS)
+				.withType(Boolean.class)
+				.withDescription("")
+				.withDefaultValue(false)
+				.build());		
         }
 
 	public String getSPos() {
@@ -336,5 +345,9 @@ public class CoNLLImporterProperties extends PepperModuleProperties {
 		Object val = getProperty(MARK_LABELS).getValue();
 		return val == null? null : ((String) val).split("-",-1);
 	}
+        
+    public Boolean importIDs() {
+    	return (Boolean) getProperty(PROP_IMPORT_IDS).getValue();
+    }
 
 }

--- a/src/main/java/org/corpus_tools/peppermodules/conll/Conll2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/conll/Conll2SaltMapper.java
@@ -81,6 +81,9 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 	public static final String NAMESPACE = "NAMESPACE";
 	public static final String DEFAULT_FEATURE = "morph";
 
+	private static final String ANNO_NAME_TOKEN_ID = "tokenID";
+	private static final String ANNO_NAME_HEAD_ID = "headID";
+
 	// separator for feature annotation values
 	private final String FEATURESEPARATOR = "\\|";
 
@@ -651,11 +654,16 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 
                                 
 				// get ID of current token's head token
+                boolean importIDs = ((CoNLLImporterProperties) getProperties()).importIDs();
 				String headIDStr = fieldValues.get(ConllDataField.HEAD.getFieldNum() - 1);
 				String headID = null;
 				try {
 					headID = headIDStr.matches("[0-9]+(\\.[0-9]+)?")? headIDStr : "-1";
-                                        headID = ((Float) Float.parseFloat(headID)).toString(); // make all string IDs decimal
+					headID = ((Float) Float.parseFloat(headID)).toString(); // make all string IDs decimal
+					if (importIDs) {
+						sToken.createAnnotation("sentence", ANNO_NAME_TOKEN_ID, Float.toString(tokenID));
+						sToken.createAnnotation("sentence", ANNO_NAME_HEAD_ID, headID);
+					}
 				} catch (NumberFormatException e) {
 					String errorMessage = String.format("Invalid numerical value '%s' for HEAD in line %d of input file '" + this.getResourceURI() + "'. Abort conversion of file " + this.getResourceURI() + ".", headIDStr, rowIndex + 1);
 					throw new PepperModuleDataException(this, errorMessage);
@@ -1088,5 +1096,7 @@ public class Conll2SaltMapper extends PepperMapperImpl {
 		}
 		return rel;
 	}
+	
+	
 
 } // ConllDep2SaltMapper


### PR DESCRIPTION
closes #20 

Importer can now import, if desired, token and head ids to facilitate further data processing. Annotation names are "token_id" and "head_id" with the text name as namespace or no namespace if text name is "null".  For changing those names please use `pepper.after.renameAnnos`.